### PR TITLE
Updated lumberjack

### DIFF
--- a/AFNetworkLumberjackLogger.podspec
+++ b/AFNetworkLumberjackLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworkLumberjackLogger'
-  s.version  = '2.0.4'
+  s.version  = '3.0.0'
   s.license  = 'MIT'
   s.summary  = 'AFNetworking 2.0 Extension for Network Request Logging with Cocoa Lumberjack'
   s.homepage = 'https://github.com/RomainBoulay/AFNetworkLumberjackLogger'

--- a/AFNetworkLumberjackLogger/AFNetworkLumberjackLogger.m
+++ b/AFNetworkLumberjackLogger/AFNetworkLumberjackLogger.m
@@ -30,10 +30,10 @@
 
 static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notification) {
     NSURLRequest *request = nil;
-    if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
-        request = [[notification object] originalRequest];
-    } else if ([[notification object] respondsToSelector:@selector(request)]) {
+    if ([[notification object] respondsToSelector:@selector(request)]) {
         request = [[notification object] request];
+    } else if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
+        request = [[notification object] originalRequest];
     }
     
     return request;

--- a/AFNetworkLumberjackLogger/AFNetworkLumberjackLogger.m
+++ b/AFNetworkLumberjackLogger/AFNetworkLumberjackLogger.m
@@ -25,21 +25,15 @@
 #import "AFURLSessionManager.h"
 
 #import <objc/runtime.h>
-#import "DDLog.h"
-
-#ifdef RELEASE
-static int ddLogLevel = LOG_LEVEL_OFF;
-#else
-static int ddLogLevel = LOG_FLAG_DEBUG;
-#endif
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 
 static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notification) {
     NSURLRequest *request = nil;
-    if ([[notification object] isKindOfClass:[AFURLConnectionOperation class]]) {
-        request = [(AFURLConnectionOperation *)[notification object] request];
-    } else if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
+    if ([[notification object] respondsToSelector:@selector(originalRequest)]) {
         request = [[notification object] originalRequest];
+    } else if ([[notification object] respondsToSelector:@selector(request)]) {
+        request = [[notification object] request];
     }
     
     return request;


### PR DESCRIPTION
- Changed import.
- No longer use ddLogLevel. (Log level is set `[AFNetworkLumberjackLogger sharedLogger].level = AFLoggerLevelDebug` and also wrapped in `#ifndef RELEASE`)
- Changed to `respondsToSelector ` as AFNetworkActivityLogger did